### PR TITLE
s/kicad-pcb.org/kicad.org/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# For PCBs designed using KiCad: http://www.kicad-pcb.org/
-# Format documentation: http://kicad-pcb.org/help/file-formats/
+# For PCBs designed using KiCad: http://www.kicad.org/
+# Format documentation: http://kicad.org/help/file-formats/
 
 # Temporary files
 *.000


### PR DESCRIPTION
kicad-pcb.org has been taken over by a malicious third party. See: https://www.kicad.org/blog/2021/10/Avoid-links-to-former-kicad-domain/